### PR TITLE
Remove round 0 from AY 24/25 onwards

### DIFF
--- a/src/history/api.py
+++ b/src/history/api.py
@@ -95,7 +95,7 @@ ClassDict = dict[str, list[dict[str, int]]]
 CourseData = dict[str, Union[str, ClassDict]]
 
 
-def get_round_numbers(year: Union[str, int]) -> tuple[int]:
+def get_round_numbers(year: Union[str, int]) -> tuple[int, ...]:
     """
     Get a tuple of round numbers for a particular academic year.
 

--- a/src/history/api.py
+++ b/src/history/api.py
@@ -5,7 +5,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Union
 
-ROUNDS = 4
+# Round 0 was discontinued in AY 24/25
+PRE_2425_YEARS = ["2122", "2223", "2324"]
+PRE_2425_ROUNDS = [0, 1, 2, 3]
+POST_2425_ROUNDS = [1, 2, 3]
+
 INF = 2147483647
 NA = -1
 BASE_DIR = Path(Path(__file__).resolve()).parent
@@ -168,7 +172,8 @@ def get_data(year: Union[str, int],
              "others": -1}
 
     # for each round, execute the SQL query
-    for round_number in range(ROUNDS):
+    round_numbers = PRE_2425_ROUNDS if year in PRE_2425_YEARS else POST_2425_ROUNDS
+    for index, round_number in enumerate(round_numbers):
         TABLE_NAME = (
             "src_history_merged_"
             f"{year}_{semester}_{ug_gd}_round_{round_number}")
@@ -207,19 +212,19 @@ def get_data(year: Union[str, int],
             }
 
             # Logic to pad skipped rounds with blanks to ensure that
-            # the list stays at length 4, corresponding to each round.
+            # the list stays at the correct length, corresponding to each round.
             if CLASSNAME in class_dict:
                 class_dict[CLASSNAME].extend(
                     [BLANK for _
-                     in range(round_number - len(class_dict[CLASSNAME]))])
+                     in range(index - len(class_dict[CLASSNAME]))])
                 class_dict[CLASSNAME].append(result)
             else:
-                class_dict[CLASSNAME] = [BLANK] * round_number
+                class_dict[CLASSNAME] = [BLANK] * index
                 class_dict[CLASSNAME].append(result)
 
     # Final padding of classes that don't have all the round information
     for key in class_dict:
-        class_dict[key] += [BLANK] * (ROUNDS - len(class_dict[key]))
+        class_dict[key] += [BLANK] * (len(round_numbers) - len(class_dict[key]))
 
     # If nothing was found, throw an error.
     if not class_dict:
@@ -266,7 +271,8 @@ def _get_set_of_all_codes(year: Union[str, int],
     conn.row_factory = sqlite3.Row
 
     # for each round, execute the SQL query
-    for round_number in range(ROUNDS):
+    round_numbers = PRE_2425_ROUNDS if year in PRE_2425_YEARS else POST_2425_ROUNDS
+    for round_number in round_numbers:
         TABLE_NAME = (
             "src_history_merged_"
             f"{year}_{semester}_{ug_gd}_round_{round_number}")

--- a/src/history/api.py
+++ b/src/history/api.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import Union
 
 # Round 0 was discontinued in AY 24/25
-PRE_2425_YEARS = ["2122", "2223", "2324"]
-PRE_2425_ROUNDS = [0, 1, 2, 3]
-POST_2425_ROUNDS = [1, 2, 3]
+PRE_2425_YEARS = ("2122", "2223", "2324")
+PRE_2425_ROUNDS = (0, 1, 2, 3)
+POST_2425_ROUNDS = (1, 2, 3)
 
 INF = 2147483647
 NA = -1
@@ -95,6 +95,23 @@ ClassDict = dict[str, list[dict[str, int]]]
 CourseData = dict[str, Union[str, ClassDict]]
 
 
+def get_round_numbers(year: Union[str, int]) -> tuple[int]:
+    """
+    Get a tuple of round numbers for a particular academic year.
+
+    Args:
+    ----
+        year (Union[str, int]): The academic year.
+
+    Returns:
+    -------
+        tuple[int]: A tuple of round numbers.
+    """
+
+    year = _clean_year(year)
+    return PRE_2425_ROUNDS if year in PRE_2425_YEARS else POST_2425_ROUNDS
+
+
 def get_data(year: Union[str, int],
              semester: Union[str, int],
              ug_gd: str,
@@ -172,7 +189,7 @@ def get_data(year: Union[str, int],
              "others": -1}
 
     # for each round, execute the SQL query
-    round_numbers = PRE_2425_ROUNDS if year in PRE_2425_YEARS else POST_2425_ROUNDS
+    round_numbers = get_round_numbers(year)
     for index, round_number in enumerate(round_numbers):
         TABLE_NAME = (
             "src_history_merged_"
@@ -271,7 +288,7 @@ def _get_set_of_all_codes(year: Union[str, int],
     conn.row_factory = sqlite3.Row
 
     # for each round, execute the SQL query
-    round_numbers = PRE_2425_ROUNDS if year in PRE_2425_YEARS else POST_2425_ROUNDS
+    round_numbers = get_round_numbers(year)
     for round_number in round_numbers:
         TABLE_NAME = (
             "src_history_merged_"

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -8,6 +8,7 @@ from flask import Flask, Response, render_template, request, send_from_directory
 from lib.nusmods import nusmods_link_of_code
 from src.history.api import (
     INF,
+    get_round_numbers,
     get_all_data,
     get_latest_year_and_sem_with_data,
     get_pdf_filepath,
@@ -29,7 +30,8 @@ def context_processor() -> dict[Any, Any]:
     """
     return {"INF": INF,
             "nusmods_link_of_code": nusmods_link_of_code,
-            "pdf_exists": pdf_exists }
+            "pdf_exists": pdf_exists,
+            "get_round_numbers": get_round_numbers }
 
 
 @app.route("/", methods=["GET", "POST"])

--- a/src/web/templates/history.html
+++ b/src/web/templates/history.html
@@ -99,7 +99,7 @@
       {% set year = request.form.get('year', '2425') %}
       {% set semester = request.form.get('semester', '1') %}
       {% set type = request.form.get('type', 'ug') %}
-      {% set start_round_num = 0 if year in ['2122', '2223', '2324'] else 1 %}
+      {% set round_nums = get_round_numbers(year) %}
       <div class="table-container">
         <table id="table-data">
           <!-- Table Headers -->
@@ -108,7 +108,7 @@
               <th class="table-code">Code</th>
               <th class="table-name">Name</th>
               <th class="table-class">Class</th>
-              {% for round_num in range(start_round_num, 4) %}
+              {% for round_num in round_nums %}
               <th class='table-round'>
                 {% if pdf_exists(year, semester, type, round_num) %}
                 {% set url = url_for('serve_pdf', year=year, semester=semester, student_type=type, round_num=round_num) %}

--- a/src/web/templates/history.html
+++ b/src/web/templates/history.html
@@ -99,6 +99,7 @@
       {% set year = request.form.get('year', '2425') %}
       {% set semester = request.form.get('semester', '1') %}
       {% set type = request.form.get('type', 'ug') %}
+      {% set start_round_num = 0 if year in ['2122', '2223', '2324'] else 1 %}
       <div class="table-container">
         <table id="table-data">
           <!-- Table Headers -->
@@ -107,7 +108,7 @@
               <th class="table-code">Code</th>
               <th class="table-name">Name</th>
               <th class="table-class">Class</th>
-              {% for round_num in range(4) %}
+              {% for round_num in range(start_round_num, 4) %}
               <th class='table-round'>
                 {% if pdf_exists(year, semester, type, round_num) %}
                 {% set url = url_for('serve_pdf', year=year, semester=semester, student_type=type, round_num=round_num) %}


### PR DESCRIPTION
## Description

Closes #36. Removes round 0 column if the year is not `"2122"`, `"2223"` or `"2324"`.

### AY 24/25

![Screenshot 2024-12-01 214919](https://github.com/user-attachments/assets/8d39aa2e-2324-4edc-8e65-d029177d02cf)

### AY 23/24

![Screenshot 2024-12-01 214926](https://github.com/user-attachments/assets/e53fe099-8d3a-4238-864e-3b20cbc19575)
